### PR TITLE
Makefile: remove unnecessary controller-gen & generate targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,11 +13,11 @@ endif
 all: manager
 
 # Run tests
-test: generate fmt vet testbin
+test: fmt vet testbin
 	go test -race -covermode atomic -coverprofile cover.out ./...
 
 # Build manager binary
-manager: generate fmt vet
+manager: fmt vet
 	go build -o bin/manager main.go
 
 # Run go fmt against code
@@ -30,10 +30,6 @@ vet:
 
 lint: golangci-lint
 	$(GOLANGCI_LINT) run
-
-# Generate code
-generate: controller-gen
-	$(CONTROLLER_GEN) object:headerFile=./hack/boilerplate.go.txt paths="./..."
 
 # Build the docker image
 docker-build: test
@@ -54,24 +50,6 @@ ifeq (, $(shell which golangci-lint))
 GOLANGCI_LINT=$(shell go env GOPATH)/bin/golangci-lint
 else
 GOLANGCI_LINT=$(shell which golangci-lint)
-endif
-
-
-# find or download controller-gen
-# download controller-gen if necessary
-controller-gen:
-ifeq (, $(shell which controller-gen))
-	@{ \
-	set -e ;\
-	CONTROLLER_GEN_TMP_DIR=$$(mktemp -d) ;\
-	cd $$CONTROLLER_GEN_TMP_DIR ;\
-	go mod init tmp ;\
-	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.3.0 ;\
-	rm -rf $$CONTROLLER_GEN_TMP_DIR ;\
-	}
-CONTROLLER_GEN=$(shell go env GOPATH)/bin/controller-gen
-else
-CONTROLLER_GEN=$(shell which controller-gen)
 endif
 
 K8S_VER ?= v1.18.2


### PR DESCRIPTION
The controller-gen is not required at all. See that it is used in kb just to gen te tesdata. 
Also, we have no markers in the code impl. 