### PR TITLE
fix: Error LeaderElectionID must be configured faced when deploy the example

### DIFF
--- a/pkg/manager/operator.go
+++ b/pkg/manager/operator.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2020 The Operator-SDK Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package manager
+
+import "math/rand"
+
+//todo: see that it is new and need to be pushed for SDK lib
+func randomString(n int) string {
+	var letters = []rune("abcdefghijklmnopqrstuvwxyz0123456789")
+
+	s := make([]rune, n)
+	for i := range s {
+		s[i] = letters[rand.Intn(len(letters))]
+	}
+	return string(s)
+}
+
+// GenRandomLeaderElectionID will return an string to be used as LeaderElectionID (E.g BpLnfgDsc2.helm.operator-sdk)
+// This method is required for Helm/Ansible based-operators using the new layout when the flag with
+// the leader-election-id is not informed.
+func GenRandomLeaderElectionID(value string) string {
+	return randomString(8) + value
+}
+
+

--- a/pkg/manager/operator_test.go
+++ b/pkg/manager/operator_test.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2020 The Operator-SDK Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package manager_test
+
+import (
+	. "github.com/joelanford/helm-operator/pkg/manager"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Checking random generation of LeaderElectionID", func() {
+
+	var _ = Describe("Checking random generation of LeaderElectionID", func() {
+		It("should generate a random leader ID with the domain informed", func() {
+			testDomain := "example.com"
+			id := GenRandomLeaderElectionID(testDomain)
+			Expect(id).NotTo(BeNil())
+			Expect(id).To(ContainSubstring(testDomain))
+		})
+	})
+})
+


### PR DESCRIPTION
Closes: https://github.com/joelanford/helm-operator/issues/10

Fix:

```
$ kubectl logs deployment.apps/nginx-operator-controller-manager -n nginx-operator-system -c manager
{"level":"info","ts":1592749240.8963294,"logger":"setup","msg":"version information","go":"go1.13.12","GOOS":"linux","GOARCH":"amd64","helm-operator":"0.0.0+git"}
{"level":"info","ts":1592749240.8965666,"logger":"setup","msg":"watching all namespaces"}
{"level":"info","ts":1592749241.3103726,"logger":"controller-runtime.metrics","msg":"metrics server is starting to listen","addr":"0.0.0.0:8383"}
{"level":"info","ts":1592749241.3121157,"logger":"controllers.Helm","msg":"Watching resource","group":"helm.sdk.operatorframework.io","version":"v1","kind":"Nginx"}
{"level":"info","ts":1592749241.3121696,"logger":"setup","msg":"configured watch","gvk":"helm.sdk.operatorframework.io/v1, Kind=Nginx","chartPath":"./helm-charts/nginx","maxConcurrentReconciles":4,"reconcilePeriod":0}
{"level":"info","ts":1592749241.3121846,"logger":"setup","msg":"starting manager"}
I0621 14:20:41.393004       1 leaderelection.go:242] attempting to acquire leader lease  nginx-operator-system/fpllngzi.helm.operator.sdk...
{"level":"info","ts":1592749241.3936195,"logger":"controller-runtime.manager","msg":"starting metrics server","path":"/metrics"}
I0621 14:20:41.402964       1 leaderelection.go:252] successfully acquired lease nginx-operator-system/fpllngzi.helm.operator.sdk
{"level":"info","ts":1592749241.4034681,"logger":"controller-runtime.controller","msg":"Starting EventSource","controller":"nginx-controller","source":"kind source: helm.sdk.operatorframework.io/v1, Kind=Nginx"}
{"level":"info","ts":1592749241.505317,"logger":"controller-runtime.controller","msg":"Starting EventSource","controller":"nginx-controller","source":"kind source: /v1, Kind=Secret"}
{"level":"info","ts":1592749241.6062837,"logger":"controller-runtime.controller","msg":"Starting Controller","controller":"nginx-controller"}
{"level":"info","ts":1592749241.6065483,"logger":"controller-runtime.controller","msg":"Starting workers","controller":"nginx-controller","worker count":4}
```