### PR TITLE
fix: example - project file

### DIFF
--- a/example/PROJECT
+++ b/example/PROJECT
@@ -1,0 +1,7 @@
+version: "2"
+domain: sdk.operatorframework.io
+repo: github.com/joelanford/nginx-operator
+resources:
+- group: apache
+  version: v1
+  kind: Tomcat


### PR DESCRIPTION
The project file is part of the example so should be in the example/ 
Fix the name of the project in the PROJECT file which should be the name of the example project. 