### PR TITLE
add log info for manager options config

### DIFF
--- a/main.go
+++ b/main.go
@@ -118,6 +118,9 @@ func main() {
 		}
 	}
 
+	setupLog.Info("setting Manager options:", "MetricsBindAddress", metricsAddr, "LeaderElection",
+		enableLeaderElection, "LeaderElectionID", leaderElectionID, "LeaderElectionNamespace", leaderElectionNamespace)
+
 	options := ctrl.Options{
 		MetricsBindAddress:      "0.0.0.0:8383",
 		LeaderElection:          enableLeaderElection,


### PR DESCRIPTION
This information is very helpful for when we are working locally running the main.go as to help users when they open their issues since we can check the values informed by seen the info in the logs.

Closes: https://github.com/joelanford/helm-operator/issues/24