### PR TITLE
fix: fix CRD for we are able to check the example

### DIFF
--- a/example/config/crd/bases/helm.sdk.operatorframework.io_nginxes.yaml
+++ b/example/config/crd/bases/helm.sdk.operatorframework.io_nginxes.yaml
@@ -3,9 +3,6 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.2.4
-  creationTimestamp: null
   name: nginxes.helm.sdk.operatorframework.io
 spec:
   group: helm.sdk.operatorframework.io
@@ -16,31 +13,12 @@ spec:
     singular: nginx
   scope: Namespaced
   versions:
-  - name: v1
-    schema:
-      openAPIV3Schema:
-        description: Nginx is the Schema for the nginxes API
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: NginxSpec defines the desired state of Nginx
-            type: object
-          status:
-            description: NginxStatus defines the observed state of Nginx
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      served: true
+      storage: true
+      subresources:
+        status: {}


### PR DESCRIPTION
Closes: https://github.com/joelanford/helm-operator/issues/28.


result:

```
$ kubectl describe nginx
Name:         nginx-sample
Namespace:    default
Labels:       <none>
Annotations:  helm.sdk.operatorframework.io/upgrade-force: true
API Version:  helm.sdk.operatorframework.io/v1
Kind:         Nginx
Metadata:
  Creation Timestamp:  2020-06-24T09:53:07Z
  Finalizers:
    uninstall-helm-release
  Generation:  1
  Managed Fields:
    API Version:  helm.sdk.operatorframework.io/v1
    Fields Type:  FieldsV1
    fieldsV1:
      f:metadata:
        f:annotations:
          .:
          f:helm.sdk.operatorframework.io/upgrade-force:
          f:kubectl.kubernetes.io/last-applied-configuration:
      f:spec:
        .:
        f:hostPort:
        f:image:
          .:
          f:nginx:
            .:
            f:repository:
            f:tag:
        f:replicaCount:
        f:service:
          .:
          f:externalPort:
          f:internalPort:
          f:name:
          f:type:
    Manager:      kubectl
    Operation:    Update
    Time:         2020-06-24T09:53:07Z
    API Version:  helm.sdk.operatorframework.io/v1
    Fields Type:  FieldsV1
    fieldsV1:
      f:metadata:
        f:finalizers:
          .:
          v:"uninstall-helm-release":
      f:spec:
        f:image:
          f:repository:
      f:status:
        .:
        f:conditions:
        f:deployedRelease:
          .:
          f:manifest:
          f:name:
    Manager:         manager
    Operation:       Update
    Time:            2020-06-24T09:53:09Z
  Resource Version:  41633
  Self Link:         /apis/helm.sdk.operatorframework.io/v1/namespaces/default/nginxes/nginx-sample
  UID:               58acf32b-591b-412a-8a97-23a1b71b7281
Spec:
  Host Port:  8009
  Image:
    Nginx:
      Repository:  nginx
      Tag:         7.0
  Replica Count:   1
  Service:
    External Port:  80
    Internal Port:  8080
    Name:           http
    Type:           LoadBalancer
Status:
  Conditions:
    Last Transition Time:  2020-06-24T09:53:09Z
    Message:               1. Get the application URL by running these commands:
     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
           You can watch the status of by running 'kubectl get --namespace default svc -w nginx-sample'
  export SERVICE_IP=$(kubectl get svc --namespace default nginx-sample --template "{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}")
  echo http://$SERVICE_IP:80

    Reason:                InstallSuccessful
    Status:                True
    Type:                  Deployed
    Last Transition Time:  2020-06-24T09:53:09Z
    Status:                True
    Type:                  Initialized
    Last Transition Time:  2020-06-24T09:53:09Z
    Status:                False
    Type:                  Irreconcilable
    Last Transition Time:  2020-06-24T09:53:09Z
    Status:                False
    Type:                  ReleaseFailed
  Deployed Release:
    Manifest:  ---
apiVersion: v1
kind: ServiceAccount
metadata:
  labels:
    app.kubernetes.io/instance: nginx-sample
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: nginx
    app.kubernetes.io/version: 1.16.0
    helm.sh/chart: nginx-0.1.0
  name: nginx-sample
  namespace: default
  ownerReferences:
  - apiVersion: helm.sdk.operatorframework.io/v1
    blockOwnerDeletion: true
    controller: true
    kind: Nginx
    name: nginx-sample
    uid: 58acf32b-591b-412a-8a97-23a1b71b7281
---
apiVersion: v1
kind: Service
metadata:
  labels:
    app.kubernetes.io/instance: nginx-sample
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: nginx
    app.kubernetes.io/version: 1.16.0
    helm.sh/chart: nginx-0.1.0
  name: nginx-sample
  namespace: default
  ownerReferences:
  - apiVersion: helm.sdk.operatorframework.io/v1
    blockOwnerDeletion: true
    controller: true
    kind: Nginx
    name: nginx-sample
    uid: 58acf32b-591b-412a-8a97-23a1b71b7281
spec:
  ports:
  - name: http
    port: 80
    protocol: TCP
    targetPort: http
  selector:
    app.kubernetes.io/instance: nginx-sample
    app.kubernetes.io/name: nginx
  type: LoadBalancer
---
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app.kubernetes.io/instance: nginx-sample
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: nginx
    app.kubernetes.io/version: 1.16.0
    helm.sh/chart: nginx-0.1.0
  name: nginx-sample
  namespace: default
  ownerReferences:
  - apiVersion: helm.sdk.operatorframework.io/v1
    blockOwnerDeletion: true
    controller: true
    kind: Nginx
    name: nginx-sample
    uid: 58acf32b-591b-412a-8a97-23a1b71b7281
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/instance: nginx-sample
      app.kubernetes.io/name: nginx
  template:
    metadata:
      labels:
        app.kubernetes.io/instance: nginx-sample
        app.kubernetes.io/name: nginx
    spec:
      containers:
      - image: nginx:1.16.0
        imagePullPolicy: IfNotPresent
        livenessProbe:
          httpGet:
            path: /
            port: http
        name: nginx
        ports:
        - containerPort: 80
          name: http
          protocol: TCP
        readinessProbe:
          httpGet:
            path: /
            port: http
        resources: {}
        securityContext: {}
      securityContext: {}
      serviceAccountName: nginx-sample

    Name:  nginx-sample
Events:
  Type     Reason           Age    From              Message
  ----     ------           ----   ----              -------
  Warning  ValueOverridden  4m16s  nginx-controller  Chart value "image.repository" overridden to "nginx" by operator
```