### PR TITLE
improve logs to allow troubleshooting

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/onsi/ginkgo v1.12.0
 	github.com/onsi/gomega v1.9.0
 	github.com/prometheus/client_golang v1.0.0
+	github.com/sergi/go-diff v1.0.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.5.1
 	go.uber.org/zap v1.13.0

--- a/go.sum
+++ b/go.sum
@@ -493,6 +493,7 @@ github.com/russross/blackfriday v1.5.2 h1:HyvC0ARfnZBqnXwABFeSZHpKvJHJJfPz81GNue
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
+github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.0.4-0.20170822132746-89742aefa4b2/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=

--- a/pkg/annotation/annotation_test.go
+++ b/pkg/annotation/annotation_test.go
@@ -22,6 +22,7 @@ import (
 	"helm.sh/helm/v3/pkg/action"
 
 	"github.com/joelanford/helm-operator/pkg/annotation"
+	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 var _ = Describe("Annotation", func() {
@@ -30,6 +31,7 @@ var _ = Describe("Annotation", func() {
 
 		BeforeEach(func() {
 			install = action.Install{}
+
 		})
 
 		Describe("DisableHooks", func() {
@@ -50,19 +52,19 @@ var _ = Describe("Annotation", func() {
 			})
 
 			It("should disable hooks", func() {
-				Expect(a.InstallOption("true")(&install)).To(Succeed())
+				Expect(a.InstallOption("true", ctrl.Log)(&install)).To(Succeed())
 				Expect(install.DisableHooks).To(BeTrue())
 			})
 
 			It("should enable hooks", func() {
 				install.DisableHooks = true
-				Expect(a.InstallOption("false")(&install)).To(Succeed())
+				Expect(a.InstallOption("false", ctrl.Log)(&install)).To(Succeed())
 				Expect(install.DisableHooks).To(BeFalse())
 			})
 
 			It("should default to false with invalid value", func() {
 				install.DisableHooks = true
-				Expect(a.InstallOption("invalid")(&install)).To(Succeed())
+				Expect(a.InstallOption("invalid", ctrl.Log)(&install)).To(Succeed())
 				Expect(install.DisableHooks).To(BeFalse())
 			})
 		})
@@ -85,7 +87,7 @@ var _ = Describe("Annotation", func() {
 			})
 
 			It("should set a description", func() {
-				Expect(a.InstallOption("test description")(&install)).To(Succeed())
+				Expect(a.InstallOption("test description", ctrl.Log)(&install)).To(Succeed())
 				Expect(install.Description).To(Equal("test description"))
 			})
 		})
@@ -116,19 +118,19 @@ var _ = Describe("Annotation", func() {
 			})
 
 			It("should disable hooks", func() {
-				Expect(a.UpgradeOption("true")(&upgrade)).To(Succeed())
+				Expect(a.UpgradeOption("true", ctrl.Log)(&upgrade)).To(Succeed())
 				Expect(upgrade.DisableHooks).To(BeTrue())
 			})
 
 			It("should enable hooks", func() {
 				upgrade.DisableHooks = true
-				Expect(a.UpgradeOption("false")(&upgrade)).To(Succeed())
+				Expect(a.UpgradeOption("false", ctrl.Log)(&upgrade)).To(Succeed())
 				Expect(upgrade.DisableHooks).To(BeFalse())
 			})
 
 			It("should default to false with invalid value", func() {
 				upgrade.DisableHooks = true
-				Expect(a.UpgradeOption("invalid")(&upgrade)).To(Succeed())
+				Expect(a.UpgradeOption("invalid", ctrl.Log)(&upgrade)).To(Succeed())
 				Expect(upgrade.DisableHooks).To(BeFalse())
 			})
 		})
@@ -151,19 +153,19 @@ var _ = Describe("Annotation", func() {
 			})
 
 			It("should force upgrades", func() {
-				Expect(a.UpgradeOption("true")(&upgrade)).To(Succeed())
+				Expect(a.UpgradeOption("true", ctrl.Log)(&upgrade)).To(Succeed())
 				Expect(upgrade.Force).To(BeTrue())
 			})
 
 			It("should not force upgrades", func() {
 				upgrade.Force = true
-				Expect(a.UpgradeOption("false")(&upgrade)).To(Succeed())
+				Expect(a.UpgradeOption("false", ctrl.Log)(&upgrade)).To(Succeed())
 				Expect(upgrade.Force).To(BeFalse())
 			})
 
 			It("should default to not forcing upgrades", func() {
 				upgrade.Force = true
-				Expect(a.UpgradeOption("invalid")(&upgrade)).To(Succeed())
+				Expect(a.UpgradeOption("invalid", ctrl.Log)(&upgrade)).To(Succeed())
 				Expect(upgrade.Force).To(BeFalse())
 			})
 		})
@@ -186,7 +188,7 @@ var _ = Describe("Annotation", func() {
 			})
 
 			It("should set a description", func() {
-				Expect(a.UpgradeOption("test description")(&upgrade)).To(Succeed())
+				Expect(a.UpgradeOption("test description", ctrl.Log)(&upgrade)).To(Succeed())
 				Expect(upgrade.Description).To(Equal("test description"))
 			})
 		})
@@ -217,19 +219,19 @@ var _ = Describe("Annotation", func() {
 			})
 
 			It("should disable hooks", func() {
-				Expect(a.UninstallOption("true")(&uninstall)).To(Succeed())
+				Expect(a.UninstallOption("true", ctrl.Log)(&uninstall)).To(Succeed())
 				Expect(uninstall.DisableHooks).To(BeTrue())
 			})
 
 			It("should enable hooks", func() {
 				uninstall.DisableHooks = true
-				Expect(a.UninstallOption("false")(&uninstall)).To(Succeed())
+				Expect(a.UninstallOption("false", ctrl.Log)(&uninstall)).To(Succeed())
 				Expect(uninstall.DisableHooks).To(BeFalse())
 			})
 
 			It("should default to false with invalid value", func() {
 				uninstall.DisableHooks = true
-				Expect(a.UninstallOption("invalid")(&uninstall)).To(Succeed())
+				Expect(a.UninstallOption("invalid", ctrl.Log)(&uninstall)).To(Succeed())
 				Expect(uninstall.DisableHooks).To(BeFalse())
 			})
 		})
@@ -252,7 +254,7 @@ var _ = Describe("Annotation", func() {
 			})
 
 			It("should set a description", func() {
-				Expect(a.UninstallOption("test description")(&uninstall)).To(Succeed())
+				Expect(a.UninstallOption("test description", ctrl.Log)(&uninstall)).To(Succeed())
 				Expect(uninstall.Description).To(Equal("test description"))
 			})
 		})

--- a/pkg/internal/sdk/diffutil/diff_util.go
+++ b/pkg/internal/sdk/diffutil/diff_util.go
@@ -1,0 +1,60 @@
+// Copyright 2018 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package diffutil
+
+import (
+	"bytes"
+	"regexp"
+	"strings"
+
+	"github.com/sergi/go-diff/diffmatchpatch"
+)
+
+func Diff(a, b string) string {
+	dmp := diffmatchpatch.New()
+
+	wSrc, wDst, warray := dmp.DiffLinesToRunes(a, b)
+	diffs := dmp.DiffMainRunes(wSrc, wDst, false)
+	diffs = dmp.DiffCharsToLines(diffs, warray)
+	var buff bytes.Buffer
+	for _, diff := range diffs {
+		text := diff.Text
+
+		switch diff.Type {
+		case diffmatchpatch.DiffInsert:
+			_, _ = buff.WriteString("\x1b[32m")
+			_, _ = buff.WriteString(prefixLines(text, "+"))
+			_, _ = buff.WriteString("\x1b[0m")
+		case diffmatchpatch.DiffDelete:
+			_, _ = buff.WriteString("\x1b[31m")
+			_, _ = buff.WriteString(prefixLines(text, "-"))
+			_, _ = buff.WriteString("\x1b[0m")
+		case diffmatchpatch.DiffEqual:
+			_, _ = buff.WriteString(prefixLines(text, " "))
+		}
+	}
+	return buff.String()
+}
+
+func prefixLines(s, prefix string) string {
+	var buf bytes.Buffer
+	lines := strings.Split(s, "\n")
+	ls := regexp.MustCompile("^")
+	for _, line := range lines[:len(lines)-1] {
+		buf.WriteString(ls.ReplaceAllString(line, prefix))
+		buf.WriteString("\n")
+	}
+	return buf.String()
+}

--- a/pkg/reconciler/reconciler_suite_test.go
+++ b/pkg/reconciler/reconciler_suite_test.go
@@ -41,6 +41,7 @@ var (
 	testenv *envtest.Environment
 	cfg     *rest.Config
 
+
 	gvk  = schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "TestApp"}
 	chrt = testutil.MustLoadChart("../../testdata/test-chart-0.1.0.tgz")
 )


### PR DESCRIPTION
**Description**
- Add the utils.diff to compare and shows manifest releases
- Add annotations logs to know when an error is faced and/or annotation is used. 

**Motivation**
Closes: https://github.com/joelanford/helm-operator/issues/14