### PR TITLE
Update lint-action to v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,9 +53,9 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Lint
-      uses: golangci/golangci-lint-action@v1
+      uses: golangci/golangci-lint-action@v2
       with:
-        version: v1.27
+        version: v1.29
 
   deploy:
     name: Deploy


### PR DESCRIPTION
Fixes #64
Ref: https://github.com/golangci/golangci-lint-action#how-to-use