### PR TITLE
fix: (helm) - do not add owner references to resources that contain the Helm keep resource-policy annotation

### DIFF
--- a/pkg/client/actionclient_test.go
+++ b/pkg/client/actionclient_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"errors"
 	"strconv"
+	"strings"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -541,6 +542,33 @@ var _ = Describe("ActionClient", func() {
 		It("fails on invalid input", func() {
 			_, err := pr.Run(bytes.NewBufferString("test"))
 			Expect(err).NotTo(BeNil())
+		})
+	})
+
+	var _ = Describe("containsResourcePolicyKeep", func() {
+		It("returns true on base case", func() {
+			annotations := map[string]string{kube.ResourcePolicyAnno: kube.KeepPolicy}
+			Expect(containsResourcePolicyKeep(annotations)).To(BeTrue())
+		})
+		It("returns false when annotation key is not found", func() {
+			annotations := map[string]string{"not-" + kube.ResourcePolicyAnno: kube.KeepPolicy}
+			Expect(containsResourcePolicyKeep(annotations)).To(BeFalse())
+		})
+		It("returns false when annotation value is not 'keep'", func() {
+			annotations := map[string]string{"not-" + kube.ResourcePolicyAnno: "not-" + kube.KeepPolicy}
+			Expect(containsResourcePolicyKeep(annotations)).To(BeFalse())
+		})
+		It("returns true when annotation is uppercase", func() {
+			annotations := map[string]string{kube.ResourcePolicyAnno: strings.ToUpper(kube.KeepPolicy)}
+			Expect(containsResourcePolicyKeep(annotations)).To(BeTrue())
+		})
+		It("returns true when annotation is has whitespace prefix and/or suffix", func() {
+			annotations := map[string]string{kube.ResourcePolicyAnno: " " + kube.KeepPolicy + "  "}
+			Expect(containsResourcePolicyKeep(annotations)).To(BeTrue())
+		})
+		It("returns true when annotation is uppercase and has whitespace prefix and/or suffix", func() {
+			annotations := map[string]string{kube.ResourcePolicyAnno: " " + strings.ToUpper(kube.KeepPolicy) + "  "}
+			Expect(containsResourcePolicyKeep(annotations)).To(BeTrue())
 		})
 	})
 })


### PR DESCRIPTION
This PR build's on #70 (I will rebase when that merges).

Credit to @mikeshng for this (see https://github.com/operator-framework/operator-sdk/pull/4389)

**Description of the change:**
Helm operator: updated the ownerRefInjectingClient to not inject the owner references if it contains the annotation: 
```
  annotations:
    "helm.sh/resource-policy": keep
```
see https://helm.sh/docs/howto/charts_tips_and_tricks/ for more details about the `keep` annotation.

**Motivation for the change:**
For the Helm operator delete CR, namespace scope resources with the Helm keep annotation are being GC'ed by Kubernetes.
This change is to make sure those resources are not owned by the CR so they won't get GC'ed.

Closes: https://github.com/operator-framework/operator-sdk/issues/4378

After this change, I can no longer reproduces the issue described in https://github.com/operator-framework/operator-sdk/issues/4378
