### PR TITLE
Improve deploy stage in Github Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,7 @@
 name: CI
 
 on:
-  push:
-    branches: [ master ]
+  push: {}
   pull_request:
     branches: [ master ]
 
@@ -59,29 +58,55 @@ jobs:
 
   deploy:
     name: Deploy
-    needs: test
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    needs:
+    - test
+    - lint
     runs-on: ubuntu-latest
     steps:
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
 
-    - name: Push helm-operator image to Quay
-      uses: docker/build-push-action@v1
+    - name: Prepare
+      id: prep
+      run: |
+        TAG=ci
+        if [[ $GITHUB_REF == refs/tags/* ]]; then
+          TAG=${GITHUB_REF#refs/tags/}
+        elif [[ $GITHUB_REF == refs/heads/* ]]; then
+          TAG=$(echo ${GITHUB_REF#refs/heads/} | sed -r 's#/+#-#g')
+        elif [[ $GITHUB_REF == refs/pull/* ]]; then
+          TAG=pr-${{ github.event.number }}
+        fi
+
+        echo ::set-output name=tag::${TAG}
+        echo ::set-output name=platforms::linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Login to Quay
+      if: github.event_name != 'pull_request'
+      uses: docker/login-action@v1
       with:
         username: ${{ secrets.QUAY_USERNAME }}
         password: ${{ secrets.QUAY_PASSWORD }}
         registry: quay.io
-        repository: joelanford/helm-operator
-        tags: master
 
-    - name: Push example nginx-operator image to Quay
-      uses: docker/build-push-action@v1
+    - name: Build helm-operator image
+      uses: docker/build-push-action@v2
       with:
-        path: example/
-        username: ${{ secrets.QUAY_USERNAME }}
-        password: ${{ secrets.QUAY_PASSWORD }}
-        registry: quay.io
-        repository: joelanford/nginx-operator
-        tags: latest
+        context: .
+        platforms: ${{ steps.prep.outputs.platforms }}
+        push: ${{ github.event_name != 'pull_request' }}
+        tags: quay.io/joelanford/helm-operator:${{ steps.prep.outputs.tag }}
+
+    - name: Build example nginx-operator image
+      uses: docker/build-push-action@v2
+      with:
+        context: ./example
+        platforms: ${{ steps.prep.outputs.platforms }}
+        push: ${{ github.event_name != 'pull_request' }}
+        tags: quay.io/joelanford/nginx-operator:${{ steps.prep.outputs.tag }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 # Build the manager binary
-FROM golang:1.15 as builder
+FROM --platform=$BUILDPLATFORM golang:1.15 as builder
+ARG TARGETOS
+ARG TARGETARCH
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -10,18 +12,16 @@ COPY go.sum go.sum
 RUN go mod download
 
 # Copy the go source
-COPY main.go main.go
-COPY pkg/ pkg/
-COPY internal/ internal/
+COPY . .
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o helm-operator main.go
+RUN GOOS=$TARGETOS GOARCH=$TARGETARCH make build
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
-COPY --from=builder /workspace/helm-operator .
+COPY --from=builder /workspace/bin/helm-operator .
 USER nonroot:nonroot
 
 ENTRYPOINT ["/helm-operator", "run"]

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ GO_BUILD_ARGS = \
     -X '$(VERSION_PKG).GitCommit=$(GIT_COMMIT)' \
   " \
 
-#all: manager
+export GO111MODULE = on
 
 # Run tests
 ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
@@ -35,7 +35,7 @@ test: fmt vet
 
 # Build manager binary
 build: fmt vet
-	go build $(GO_BUILD_ARGS) -o bin/helm-operator main.go
+	CGO_ENABLED=0 go build $(GO_BUILD_ARGS) -o bin/helm-operator main.go
 
 # Run go fmt against code
 fmt:
@@ -49,13 +49,6 @@ lint: golangci-lint
 	$(GOLANGCI_LINT) run
 lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes
 	$(GOLANGCI_LINT) run --fix
-# Build the docker image
-docker-build:
-	docker build -t quay.io/joelanford/helm-operator:$(VERSION) .
-
-# Push the docker image
-docker-push:
-	docker push quay.io/joelanford/helm-operator:$(VERSION)
 
 # find or download controller-gen
 # download controller-gen if necessary


### PR DESCRIPTION
The improvements are:
- Upgrade to docker/build-push-action@v2
- For PR events, run docker builds without pushing
- Use docker buildx to build multi-arch images (amd64, arm64, ppc64le, s390x)