### PR TITLE
Add "release" makefile target and github action to run GoReleaser 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 name: CI
 
 on:
-  push: {}
   pull_request:
     branches: [ main ]
 
@@ -55,58 +54,3 @@ jobs:
       uses: golangci/golangci-lint-action@v2
       with:
         version: v1.35.2
-
-  deploy:
-    name: Deploy
-    needs:
-    - test
-    - lint
-    runs-on: ubuntu-latest
-    steps:
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-
-    - name: Prepare
-      id: prep
-      run: |
-        TAG=ci
-        if [[ $GITHUB_REF == refs/tags/* ]]; then
-          TAG=${GITHUB_REF#refs/tags/}
-        elif [[ $GITHUB_REF == refs/heads/* ]]; then
-          TAG=$(echo ${GITHUB_REF#refs/heads/} | sed -r 's#/+#-#g')
-        elif [[ $GITHUB_REF == refs/pull/* ]]; then
-          TAG=pr-${{ github.event.number }}
-        fi
-
-        echo ::set-output name=tag::${TAG}
-        echo ::set-output name=platforms::linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
-
-    - name: Login to Quay
-      if: github.event_name != 'pull_request'
-      uses: docker/login-action@v1
-      with:
-        username: ${{ secrets.QUAY_USERNAME }}
-        password: ${{ secrets.QUAY_PASSWORD }}
-        registry: quay.io
-
-    - name: Build helm-operator image
-      uses: docker/build-push-action@v2
-      with:
-        context: .
-        platforms: ${{ steps.prep.outputs.platforms }}
-        push: ${{ github.event_name != 'pull_request' }}
-        tags: quay.io/joelanford/helm-operator:${{ steps.prep.outputs.tag }}
-
-    - name: Build example nginx-operator image
-      uses: docker/build-push-action@v2
-      with:
-        context: ./example
-        platforms: ${{ steps.prep.outputs.platforms }}
-        push: ${{ github.event_name != 'pull_request' }}
-        tags: quay.io/joelanford/nginx-operator:${{ steps.prep.outputs.tag }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,74 @@
+name: Deploy
+
+on:
+  push:
+    tags:
+      - v*
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  goreleaser:
+    name: GoReleaser
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.15
+
+    - name: Create release
+      run: |
+        SNAPSHOT="--snapshot"
+        if [[ $GITHUB_REF == refs/tags/* ]]; then
+          SNAPSHOT=""
+        fi
+        GORELEASER_ARGS="--rm-dist ${SNAPSHOT}" make release
+
+  docker:
+    name: Docker
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Prepare
+      id: prep
+      run: |
+        IMG=quay.io/joelanford/helm-operator
+        if [[ $GITHUB_REF == refs/tags/* ]]; then
+          TAG=${GITHUB_REF#refs/tags/}
+          MAJOR_MINOR=${TAG%.*}
+          echo ::set-output name=tags::${IMG}:${TAG},${IMG}:${MAJOR_MINOR}
+
+        elif [[ $GITHUB_REF == refs/pull/* ]]; then
+          TAG=pr-${{ github.event.number }}
+          echo ::set-output name=tags::${IMG}:${TAG}
+        fi
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Login to Quay
+      if: github.event_name != 'pull_request'
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_PASSWORD }}
+        registry: quay.io
+
+    - name: Build helm-operator image
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
+        push: ${{ github.event_name != 'pull_request' }}
+        tags: ${{ steps.prep.outputs.tags }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Binaries for programs and plugins
 /bin
 /tools/bin
+/dist
 
 # Other IDE files
 .idea

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,47 @@
+# Global environment variables for builds.
+env:
+  - CGO_ENABLED=0
+  - GO111MODULE=on
+  - GOPROXY=https://proxy.golang.org|direct
+  - VERSION_PKG=github.com/joelanford/helm-operator/internal/version
+
+# Hooks to run before any build is run.
+before:
+  hooks:
+    - go version | grep --quiet "go1\.15\.6" || echo "Go binary version must be 1.15.6"
+    - go mod download
+
+# Binary builds.
+builds:
+  # operator-sdk build steps
+  - id: helm-operator
+    binary: helm-operator
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    asmflags:
+      - all=-trimpath={{ dir .Env.PWD }}
+    gcflags:
+      - all=-trimpath={{ dir .Env.PWD }}
+    ldflags:
+      - -s
+      - -w
+      - -X {{ .Env.VERSION_PKG }}.ScaffoldVersion={{ .Env.SCAFFOLD_VERSION }}
+      - -X {{ .Env.VERSION_PKG }}.GitVersion={{ .Env.GIT_VERSION }}
+      - -X {{ .Env.VERSION_PKG }}.GitCommit={{ .Env.GIT_COMMIT }}
+    targets:
+      - darwin_amd64
+      - linux_amd64
+      - linux_arm64
+      - linux_ppc64le
+      - linux_s390x
+
+# Use most recent tag and short commit for snapshot version.
+snapshot:
+  name_template: "{{ .Env.GIT_VERSION }}"
+
+# We don't use archives, so skip creating them.
+archives:
+  - format: binary
+    name_template: "{{ .Binary }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}"
+
+checksum:
+  name_template: "checksums.txt"

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 # GO_BUILD_ARGS should be set when running 'go build' or 'go install'.
 VERSION_PKG = "$(shell go list -m)/internal/version"
-SCAFFOLD_VERSION = $(shell git describe --abbrev=0)
-GIT_VERSION = $(shell git describe --dirty --tags --always)
-GIT_COMMIT = $(shell git rev-parse HEAD)
+export SCAFFOLD_VERSION = $(shell git describe --abbrev=0)
+export GIT_VERSION = $(shell git describe --dirty --tags --always)
+export GIT_COMMIT = $(shell git rev-parse HEAD)
 BUILD_DIR = $(PWD)/bin
 GO_BUILD_ARGS = \
   -gcflags "all=-trimpath=$(shell dirname $(shell pwd))" \
@@ -51,6 +51,11 @@ fix:
 .PHONY: lint
 lint:
 	fetch golangci-lint 1.35.2 && golangci-lint run
+
+.PHONY: release
+release: GORELEASER_ARGS ?= --snapshot --rm-dist
+release:
+	fetch goreleaser 0.155.0 && goreleaser $(GORELEASER_ARGS)
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
This PR adds a goreleaser make target and updates the github actions
workflows to run the deploy stages (GoReleaser and Docker) for tags
and PRs (PR artifacts aren't pushed anywhere).