### PR TITLE
pkg/reconciler: force upgrade if release is failed or superseded

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,10 @@ all: test lint build
 # Run tests
 .PHONY: test
 export KUBEBUILDER_ASSETS := $(TOOLS_BIN_DIR)
+TESTPKG ?= ./...
 CR_VERSION=$(shell go list -m sigs.k8s.io/controller-runtime | cut -d" " -f2 | sed 's/^v//')
 test:
-	fetch envtest $(CR_VERSION) && go test -race -covermode atomic -coverprofile cover.out ./...
+	fetch envtest $(CR_VERSION) && go test -race -covermode atomic -coverprofile cover.out $(TESTPKG)
 
 # Build manager binary
 .PHONY: build


### PR DESCRIPTION
If the current release is in the Failed or Superseded state, force an upgrade. This resolves a potential issue where a failed or superceded release is never redeployed.

See https://github.com/joelanford/helm-operator/issues/63#issuecomment-766509014